### PR TITLE
Update schema.sql

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -11,7 +11,7 @@ create table submission (
   submission_id integer primary key autoincrement,
   user_id integer not null,
   filename text not null,
-  submit_date integer not null
+  submit_date integer not null,
   public_score real not null,
   private_score real not null,
   total_score real not null


### PR DESCRIPTION
14th line in schema.sql is missing a comma. As a result, python throws a syntax error

`Traceback (most recent call last):
  File "leaderBoardApp.py", line 481, in <module>
    init_db()
  File "leaderBoardApp.py", line 80, in init_db
    db.cursor().executescript(f.read())
sqlite3.OperationalError: near "public_score": syntax error`